### PR TITLE
Prevent division by zero in rule-of-three calculator

### DIFF
--- a/script.js
+++ b/script.js
@@ -67,7 +67,15 @@ document.querySelectorAll('.calculator form').forEach(form => {
           form.querySelector('#inputX').value = '';
           return showError(form, "Fill all fields.");
         }
+        if (A === 0) {
+          form.querySelector('#inputX').value = '';
+          return showError(form, "A cannot be zero.");
+        }
         const X = (B * C) / A;
+        if (!isFinite(X)) {
+          form.querySelector('#inputX').value = '';
+          return showError(form, "Invalid calculation.");
+        }
         form.querySelector('#inputX').value = X.toFixed(2).replace('.', ',');
         form.querySelector('.result').innerText = `X = ${X.toFixed(2).replace('.', ',')}`;
         break;


### PR DESCRIPTION
## Summary
- Validate Rule of Three inputs to avoid dividing by zero
- Report errors when result is not a finite number

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689888e3124c832692837023e60e0d85