### PR TITLE
Rename leverage profit label to match variables

### DIFF
--- a/script.js
+++ b/script.js
@@ -77,7 +77,7 @@ document.querySelectorAll('.calculator form').forEach(form => {
         const percentage = toNumber(form.querySelector('#percentage').value);
         if (leverage === null || percentage === null) return showError(form, "All fields required");
         const leveragedProfit = leverage * percentage;
-        form.querySelector('.result').innerText = `Leverage Profit: ${leveragedProfit.toFixed(2)}%`;
+        form.querySelector('.result').innerText = `Leveraged Profit: ${leveragedProfit.toFixed(2)}%`;
         break;
       }
       case 'profitCalculator': {


### PR DESCRIPTION
## Summary
- Rename leverage result label from "Leverage Profit" to "Leveraged Profit" so text aligns with `leveragedProfit` variable and DOM ID

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_689889ecff948326b86fbdce0681e0cc