### PR TITLE
Handle empty inputs in toNumber

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,5 +1,7 @@
 function toNumber(value) {
-  const num = Number(value.replace(',', '.'));
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const num = Number(trimmed.replace(',', '.'));
   return isNaN(num) ? null : num;
 }
 
@@ -90,7 +92,7 @@ document.querySelectorAll('.calculator form').forEach(form => {
       }
       case 'compoundInterestCalculator': {
         const initialInvestment = toNumber(form.querySelector('#initialInvestment').value);
-        const contribution = toNumber(form.querySelector('#contribution').value) || 0;
+        const contribution = toNumber(form.querySelector('#contribution').value) ?? 0;
         const rate = toNumber(form.querySelector('#rate').value);
         const period = toNumber(form.querySelector('#period').value);
         const freq = form.querySelector('#compoundFrequency').value;


### PR DESCRIPTION
## Summary
- Return `null` when numeric inputs are empty or whitespace only
- Ensure optional contributions default to zero using nullish coalescing

## Testing
- `node - <<'NODE'\nfunction toNumber(value) {\n  const trimmed = value.trim();\n  if (!trimmed) return null;\n  const num = Number(trimmed.replace(',', '.'));\n  return isNaN(num) ? null : num;\n}\nconsole.log('empty:', toNumber(''));\nconsole.log('spaces:', toNumber('   '));\nconsole.log('comma:', toNumber('1,5'));\nconsole.log('zero:', toNumber('0'));\nNODE`

------
https://chatgpt.com/codex/tasks/task_e_689889ef38348326b2b46c9ca3a4da2d