### PR TITLE
Fix form selector for calculator submissions

### DIFF
--- a/script.js
+++ b/script.js
@@ -42,7 +42,7 @@ document.querySelectorAll('.calculator input').forEach(input => {
   });
 });
 
-document.querySelectorAll('.calculator form').forEach(form => {
+document.querySelectorAll('form.calculator').forEach(form => {
   form.addEventListener('submit', e => {
     e.preventDefault();
     clearResult(form);


### PR DESCRIPTION
## Summary
- ensure every calculator form is selected directly with `form.calculator`

## Testing
- `node <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68988bbe581483269e523131c588cddd