### PR TITLE
Add accessible labels for Rule of Three calculator

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,14 +33,18 @@
         <h2>Rule of Three Calculator</h2>
         <div class="rule-three-block">
           <div class="rule-three-row">
+            <label for="inputA" class="screen-reader-only">A</label>
             <input type="number" id="inputA" step="any" placeholder="A" />
             <span class="rule-three-label">IS TO</span>
+            <label for="inputB" class="screen-reader-only">B</label>
             <input type="number" id="inputB" step="any" placeholder="B" />
           </div>
           <div class="rule-three-equal">AS</div>
           <div class="rule-three-row">
+            <label for="inputC" class="screen-reader-only">C</label>
             <input type="number" id="inputC" step="any" placeholder="C" />
             <span class="rule-three-label">IS TO</span>
+            <label for="inputX" class="screen-reader-only">X</label>
             <input type="text" id="inputX" placeholder="X" disabled style="font-weight:bold; font-size:1.2em;" />
           </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -7,6 +7,18 @@
   --white3: rgba(255,255,255,0.56);
 }
 
+.screen-reader-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 body {
   font-family: Arial, sans-serif;
   background-color: var(--primary-bg);


### PR DESCRIPTION
## Summary
- add screen-reader-only labels for Rule of Three calculator inputs
- introduce `.screen-reader-only` CSS helper class for hidden accessible text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68988bc638d483268ee60e18c49aad75