### PR TITLE
Refactor calculators and broaden input support

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,22 +94,24 @@
           <input type="number" id="initialInvestment" step="any" inputmode="decimal" name="initialInvestment" required />
         </div>
         <div class="form-group">
-          <label for="contribution">Daily/Monthly Contribution ($):</label>
+          <label for="contribution">Contribution per Period ($):</label>
           <input type="number" id="contribution" step="any" inputmode="decimal" name="contribution" />
         </div>
         <div class="form-group">
-          <label for="rate">Daily/Monthly Interest Rate (%):</label>
+          <label for="rate">Annual Interest Rate (%):</label>
           <input type="number" id="rate" step="any" inputmode="decimal" name="rate" required />
         </div>
         <div class="form-group">
-          <label for="period">Investment Period (days/months):</label>
+          <label for="period">Investment Period (years):</label>
           <input type="number" id="period" step="any" inputmode="decimal" name="period" required />
         </div>
         <div class="form-group">
           <label for="compoundFrequency">Compounding Frequency:</label>
           <select id="compoundFrequency" name="compoundFrequency">
             <option value="daily">Daily</option>
+            <option value="weekly">Weekly</option>
             <option value="monthly">Monthly</option>
+            <option value="yearly">Yearly</option>
           </select>
         </div>
         <button type="submit">Calculate</button>

--- a/tests/calculations.test.js
+++ b/tests/calculations.test.js
@@ -1,0 +1,19 @@
+const { compoundInterestCalc, b3ProfitCalc } = require('../script');
+
+describe('compoundInterestCalc', () => {
+  test('calculates compound interest with contributions', () => {
+    const total = compoundInterestCalc(1000, 100, 12, 1, 'monthly');
+    const r = 0.12 / 12;
+    const n = 12;
+    const expected = 1000 * Math.pow(1 + r, n) + 100 * ((Math.pow(1 + r, n) - 1) / r) * (1 + r);
+    expect(total).toBeCloseTo(expected);
+  });
+});
+
+describe('b3ProfitCalc', () => {
+  test('computes profit with tax', () => {
+    const total = b3ProfitCalc(10, 5, 'miniIndice', true);
+    expect(total).toBeCloseTo(10 * 0.2 * 5 * 0.8);
+  });
+});
+

--- a/tests/toNumber.test.js
+++ b/tests/toNumber.test.js
@@ -9,6 +9,12 @@ describe('toNumber', () => {
     expect(toNumber('1,23')).toBeCloseTo(1.23);
   });
 
+  test('handles thousand separators and spaces', () => {
+    expect(toNumber('1.234,56')).toBeCloseTo(1234.56);
+    expect(toNumber('1,234.56')).toBeCloseTo(1234.56);
+    expect(toNumber('1 234,56')).toBeCloseTo(1234.56);
+  });
+
   test('non-numeric strings return null', () => {
     expect(toNumber('abc')).toBeNull();
   });

--- a/toNumber.js
+++ b/toNumber.js
@@ -1,6 +1,20 @@
 function toNumber(value) {
-  if (value === '') return null;
-  const num = Number(value.replace(',', '.'));
+  if (value === null || value === undefined) return null;
+  const str = String(value).trim();
+  if (str === '') return null;
+  let normalized = str.replace(/\s+/g, '');
+  const hasComma = normalized.includes(',');
+  const hasDot = normalized.includes('.');
+  if (hasComma && hasDot) {
+    if (normalized.lastIndexOf(',') > normalized.lastIndexOf('.')) {
+      normalized = normalized.replace(/\./g, '').replace(',', '.');
+    } else {
+      normalized = normalized.replace(/,/g, '');
+    }
+  } else if (hasComma) {
+    normalized = normalized.replace(/,/g, '.');
+  }
+  const num = Number(normalized);
   return isNaN(num) ? null : num;
 }
 


### PR DESCRIPTION
## Summary
- Cache calculator result elements and expose pure helpers for compound interest and B3 profit
- Handle weekly and yearly compounding options with annual interest rate input
- Improve numeric parsing to accept spaces and thousand separators
- Add unit tests for compound interest and B3 profit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898a3c48fb48326808980cfeef21ea3