### PR TITLE
fix: preserve proportion input border radius

### DIFF
--- a/style.css
+++ b/style.css
@@ -287,6 +287,7 @@ textarea:disabled {
 .rule-three-row input:focus {
   border: 2px solid var(--white3);
   outline: none;
+  border-radius: 8px;
 }
 
   .rule-three-label {


### PR DESCRIPTION
## Summary
- keep proportion calculator inputs at 8px radius when focused

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898ad023b4c8326b5a314f365a22090