### PR TITLE
Make tax deducted row fully clickable

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,10 +146,10 @@
           <label for="points">Points:</label>
           <input type="number" id="points" step="0.5" inputmode="decimal" name="points" required />
         </div>
-        <div class="checkbox-container">
+        <label class="checkbox-container">
           <span>Tax Deducted</span>
           <input type="checkbox" id="taxDeducted" name="taxDeducted" />
-        </div>
+        </label>
         <button type="submit">Calculate</button>
         <div class="result" id="b3ProfitResultText"></div>
       </form>

--- a/style.css
+++ b/style.css
@@ -194,16 +194,17 @@ button {
   .checkbox-container {
     display: flex;
     align-items: center;
-    gap: 8px;
+    justify-content: space-between;
+    width: 100%;
     margin-top: 8px;
     margin-bottom: 8px;
     border-radius: 16px;
+    cursor: pointer;
   }
 
 .checkbox-container input[type="checkbox"] {
   width: 18px;
   height: 18px;
-  margin-left: 8px;
   border-radius: 16px;
 }
 


### PR DESCRIPTION
## Summary
- make Tax Deducted checkbox row clickable across its full width
- add styling so label spans the form width and uses pointer cursor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898ae08094883268bcf456b4404f2c2