### PR TITLE
Refine button styles for contrast

### DIFF
--- a/style.css
+++ b/style.css
@@ -44,7 +44,7 @@ body {
 
 .toggle-button {
   padding: 16px 32px;
-  border: 2px solid var(--white2);
+  border: 2px solid var(--white);
   border-radius: 16px;
   background-color: transparent;
   color: var(--white);
@@ -152,26 +152,27 @@ body {
 
     .calculator button {
       padding: 16px 32px;
-      border: none;
+      border: 2px solid var(--white);
       border-radius: 8px;
-      background-color: var(--primary);
-      color: var(--on-primary);
+      background-color: transparent;
+      color: var(--white);
       cursor: pointer;
       width: 100%;
       box-sizing: border-box;
       margin-top: 24px;
-      box-shadow: 0 3px 5px rgba(0,0,0,0.3);
-      transition: background-color 0.3s, box-shadow 0.3s;
+      box-shadow: none;
+      transition: border-color 0.3s, color 0.3s;
     }
 
 .calculator button:focus,
 .calculator button:hover {
-  background-color: var(--primary-hover);
-  outline: 2px solid var(--primary-hover);
+  border-color: var(--primary);
+  color: var(--primary);
+  outline: none;
 }
 
 .calculator button:active {
-  box-shadow: 0 0 4px 1px var(--primary-hover);
+  box-shadow: none;
 }
 
   .result {


### PR DESCRIPTION
## Summary
- improve calculator toggle button contrast with solid borders
- restyle calculate button with transparent background and border

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1d7c4e824832694e22d67f2281a31